### PR TITLE
Add support for creating containerd based VMs to CT

### DIFF
--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -84,7 +84,7 @@ function banner() {
  ${CWhite}| _ \_ _ ___${CProxmox}__ __${CWhite}_ __  ___${CProxmox}__ __ ${CDietPi}|   \(_)___| |_| _ (_)
  ${CWhite}|  _/ '_/ _ ${CProxmox}\ \ /${CWhite} '  \/ _ ${CProxmox}\ \ / ${CDietPi}| |) | / -_)  _|  _/ |
  ${CWhite}| | |_| \___${CProxmox}/_\_\\${CWhite}_|_|_\___${CProxmox}/_\_\ ${CDietPi}|___/|_\___|\__|_| |_| 
- ${CWhite}|_|${CBlue}github.com/thushan/proxmox-vm-to-ct${ENDMARKER}          ${CYellow}v${VERSION}${ENDMARKER}
+ ${CWhite}|_|      ${CBlue}github.com/thushan/proxmox-vm-to-ct${ENDMARKER}    ${CYellow}v${VERSION}${ENDMARKER}
 
    Your ${CGrey}Virtual Machine${ENDMARKER} to ${CGrey}Container${ENDMARKER} Conversion Script
 
@@ -481,29 +481,30 @@ function main() {
 }
 
 function usage() {
-    echo "Usage: $0 --source <hostname> --target <name> --storage <name> [options]"
+    banner
+    echo "Usage: ${CYellow}$0${ENDMARKER} ${CBlue}--source${ENDMARKER} <hostname> ${CBlue}--target${ENDMARKER} <name> ${CBlue}--storage${ENDMARKER} <name> [options]"
     echo "Options:"
-    echo "  --storage <name>"
+    echo "  ${CCyan}--storage${ENDMARKER} <name>"
     echo "      Name of the Proxmox Storage container (Eg. local-zfs, local-lvm, etc)"
-    echo "  --target <name>"
+    echo "  ${CCyan}--target${ENDMARKER} <name>"
     echo "      Name of the container to create (Eg. postgres-ct)"
-    echo "  --source <hostname>"
+    echo "  ${CCyan}--source${ENDMARKER} <hostname>"
     echo "      Source VM to convert to CT (Eg. postgres-vm.fritz.box or 192.168.0.10)"
-    echo "  --source-output <path>, --output <path>, -o <path>"
+    echo "  ${CCyan}--source-output${ENDMARKER} <path>, ${CCyan}--output${ENDMARKER} <path>, ${CCyan}-o${ENDMARKER} <path>"
     echo "      Location of the source VM output (default: /tmp/proxmox-vm-to-ct/<hostname>.tar.gz)"
-    echo "  --cleanup"
+    echo "  ${CCyan}--cleanup${ENDMARKER}"
     echo "      Cleanup the source compressed image after conversion (the *.tar.gz file)"
-    echo "  --default-config"
+    echo "  ${CCyan}--default-config${ENDMARKER}"
     echo "      Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)"
-    echo "  --default-config-containerd, --default-config-docker"
-    echo "      Default configuration for a containerd container (2 CPU, 2GB RAM, 20GB Disk, privileged, features: nesting, keyctl)"
-    echo "  --ignore-prep"
+    echo "  ${CCyan}--default-config-containerd${ENDMARKER}, ${CCyan}--default-config-docker${ENDMARKER}"
+    echo "      Default configuration for containerd containers (default + privileged, features: nesting, keyctl)"
+    echo "  ${CCyan}--ignore-prep${ENDMARKER}"
     echo "      Ignore modifying the VM before snapshotting"
-    echo "  --ignore-dietpi"
+    echo "  ${CCyan}--ignore-dietpi${ENDMARKER}"
     echo "      Ignore DietPi specific modifications on the VM before snapshotting. (ignored with --ignore-prep)"
-    echo "  --prompt-password"
+    echo "  ${CCyan}--prompt-password${ENDMARKER}"
     echo "      Prompt for a password for the container, temporary one generated & displayed otherwise"
-    echo "  --help"
+    echo "  ${CCyan}--help${ENDMARKER}"
     echo "      Display this help message"
 }
 

--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -449,10 +449,10 @@ function ensure_env() {
 function cleanup () {
     # https://www.youtube.com/watch?v=4F4qzPbcFiA
     local c_status="Cleaning up..."
+    local template_size_before=$(du -h "$PVE_SOURCE_OUTPUT" | cut -f1)
+
     msg "$c_status"
     if [[ "$OPT_CLEANUP" -eq 1 || "$CT_SUCCESS" -eq 0 ]] && [[ -f "$PVE_SOURCE_OUTPUT" ]]; then
-        
-        local template_size_before=$(du -h "$PVE_SOURCE_OUTPUT" | cut -f1)
 
         rm -rf "$PVE_SOURCE_OUTPUT"
         
@@ -461,6 +461,8 @@ function cleanup () {
         else
             check_ok "Removed  ${CBlue}$PVE_SOURCE_OUTPUT${ENDMARKER} (-$template_size_before)"
         fi 
+    else
+        check_ok "Leaving  ${CBlue}$PVE_SOURCE_OUTPUT${ENDMARKER} ($template_size_before)"
     fi
     msg_done "$c_status"
 }
@@ -511,6 +513,8 @@ function usage() {
     echo "      Location of the source VM output (default: /tmp/proxmox-vm-to-ct/<hostname>.tar.gz)"
     echo "  ${CCyan}--cleanup${ENDMARKER}"
     echo "      Cleanup the source compressed image after conversion (the *.tar.gz file)"
+    echo "  ${CCyan}--no-cleanup${ENDMARKER}"
+    echo "      Leave any files created for the container alone (opposite to ${CCyan}--cleanup${ENDMARKER})"
     echo "  ${CCyan}--default-config${ENDMARKER}"
     echo "      Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)"
     echo "  ${CCyan}--default-config-containerd${ENDMARKER}, ${CCyan}--default-config-docker${ENDMARKER}"
@@ -549,6 +553,9 @@ while [ "$#" -gt 0 ]; do
         ;;
     --cleanup)
         OPT_CLEANUP=1
+        ;;
+    --no-cleanup)
+        OPT_CLEANUP=0
         ;;
     --default-config)
         OPT_DEFAULT_CONFIG=$OPT_DEFAULTS_DEFAULT

--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -166,6 +166,15 @@ function check_proxmox_storage() {
         fatal "Please specify a valid storage name"
     fi
 }
+
+function check_container_settings() {
+    if [[ "$CT_UNPRIVILEGED" -eq 1 ]]; then
+        check_info "Creating ${CGreen}UNPRIVILLEGED${ENDMARKER} container."
+    elif [[ $CT_UNPRIVILEGED -eq 0 ]]; then
+        check_info "Creating ${CRed}PRIVILLEGED${ENDMARKER} container."
+    fi
+}
+
 function check_proxmox_container() {
     local containers=$(pct list | awk 'NR>1 {print $NF}')    
     if [[ ${containers[*]} =~ $PVE_TARGET ]]; then
@@ -272,9 +281,16 @@ function map_ct_to_defaults() {
 function print_opts() {
     local c_status="Gathering options..."    
     local CT_SECURE_PASSWORD="**********"
+    local CT_DEFAULT_CONFIG_TYPE=""
     
     if [[ "$OPT_PROMPT_PASS" -eq 0 ]] && [[ "$INT_PROMPT_PASS" -eq 0 ]]; then
         CT_SECURE_PASSWORD=$CT_PASSWORD
+    fi
+
+    if [[ "$OPT_DEFAULT_CONFIG" -eq $OPT_DEFAULTS_CONTAINERD ]]; then
+        CT_DEFAULT_CONFIG_TYPE="containerd / docker"
+    elif [[ "$OPT_DEFAULT_CONFIG" -eq $OPT_DEFAULTS_DEFAULT ]]; then
+        CT_DEFAULT_CONFIG_TYPE="default"
     fi
 
     msg "$c_status"
@@ -284,7 +300,7 @@ function print_opts() {
     msg3 "- Cleanup:        ${CCyan}$OPT_CLEANUP${ENDMARKER}"
     msg3 "Target CT:        ${CBlue}$PVE_TARGET${ENDMARKER}"
     msg3 "- Password:       ${CRed}$CT_SECURE_PASSWORD${ENDMARKER}"
-    msg3 "Default Config:   ${CBlue}$OPT_DEFAULT_CONFIG${ENDMARKER}"
+    msg3 "Default Config:   ${CBlue}$CT_DEFAULT_CONFIG_TYPE${ENDMARKER}"
     msg3 "- ID:             ${CCyan}$CT_NEXT_ID${ENDMARKER}"
     msg3 "- ARCH:           ${CCyan}$CT_ARCH${ENDMARKER}"
     msg3 "- CPU:            ${CCyan}$CT_CPU${ENDMARKER}"
@@ -307,6 +323,7 @@ function validate_env() {
     check_proxmox_version
     check_proxmox_storage
     check_proxmox_container
+    check_container_settings
     msg_done "$c_status"
 }
 

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,8 @@ Options:
       Location of the source VM output (default: /tmp/proxmox-vm-to-ct/<hostname>.tar.gz)
   --cleanup
       Cleanup the source compressed image after conversion (the *.tar.gz file)
+  --no-cleanup
+    Leave any files created for the container alone (opposite to --cleanup)
   --default-config
       Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)
   --default-config-containerd, --default-config-docker

--- a/readme.md
+++ b/readme.md
@@ -178,8 +178,8 @@ Options:
       Cleanup the source compressed image after conversion (the *.tar.gz file)
   --default-config
       Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)
-  --default-config-docker
-      Default configuration for a docker container (2 CPU, 2GB RAM, 20GB Disk, privileged, features: nesting, keyctl)
+  --default-config-containerd, --default-config-docker
+      Default configuration for creating a containerd container (2 CPU, 2GB RAM, 20GB Disk, privileged, features: nesting, keyctl)
   --ignore-prep
       Ignore modifying the VM before snapshotting
   --ignore-dietpi

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ If you want to avoid [changes to the vm](#dietpi-changes) by the script, use the
 
 The [default CT configuration](#default-configuration) is not designed for VMs that have a containerd (Docker/Podman) engine installed. If your VM has Docker or Podman installed, converting to a CT will generate errors as described in [ISSUE: Failed to Create CT](https://github.com/thushan/proxmox-vm-to-ct/issues/2#issuecomment-1898335593).
 
-You can create a privilleged container with additional features required (`nesting` & `keyctl`) by using the `--default-config-containerd` (or `--default-config-docker`)
+You can create a privilleged container with additional features required by using the `--default-config-containerd` (or `--default-config-docker`):
 
 ```
 ./proxmox-vm-to-ct.sh --source 192.168.0.152 \
@@ -160,6 +160,8 @@ You can create a privilleged container with additional features required (`nesti
                       --storage local-lvm \
                       --default-config-docker
 ```
+
+See what's included with [default containerd](#default-configuration---containerd--docker--podman) for more information.
 
 ## Usage
 ```
@@ -192,18 +194,67 @@ Options:
 
 ### Default Configuration
 
+Switch: `--default-config`
+
 The default Container settings (stored in `CT_DEFAULT_*` vars) that are activated with the switch `--default-config` are:
 
-* CPU: 2 cores
-* RAM: 2048MB
-* HDD: 20GB
-* NET: `name=eth0,ip=dhcp,ip6=auto,bridge=vmbr0,firewall=1`
-* ARCH: amd64
-* OSTYPE: debian
-* ONBOOT: `false`
-* UNPRIVILEGED: `true`
+<table>
+  <tr>
+    <th align="right">CPU</th>
+    <td>2 Cores</td>
+  </tr>
+  <tr>
+    <th align="right">RAM</th>
+    <td>2048MB</td>
+  </tr>
+  <tr>
+    <th align="right">HDD</th>
+    <td>20GB</td>
+  </tr>
+  <tr>
+    <th align="right">NET</th>
+    <td><code>name=eth0,ip=dhcp,ip6=auto,bridge=vmbr0,firewall=1</code></td>
+  </tr>
+  <tr>
+    <th align="right">ARCH</th>
+    <td>amd64</td>
+  </tr>
+  <tr>
+    <th align="right">OSTYPE</th>
+    <td>debian</td>
+  </tr>
+  <tr>
+    <th align="right">ONBOOT</th>
+    <td><code>false</code></td>
+  </tr>
+  <tr>
+    <th align="right">FEATURES</th>
+    <td><code>nesting</code></td>
+  </tr>
+  <tr>
+    <th align="right">UNPRIVILEGED</th>
+    <td><code>true</code></td>
+  </tr>
+</table>
 
 At this time, you'll have to modify the file to change that configuration - but will be implemented soon via commandline.
+
+### Default Configuration - containerd / Docker / Podman
+
+Switch: `--default-config-containerd`, `--default-config-docker`
+
+For VM's that have a `containerd` instance (or Docker, Podman etc) we need a few more defaults. So in addition to the [default configuration](#default-configuration), this switch enables:
+
+<table>
+  <tr>
+    <th align="right">FEATURES</th>
+    <td><code>nesting</code>, <code>keyctl</code></td>
+  </tr>
+  <tr>
+    <th align="right">UNPRIVILEGED</th>
+    <td><em><code>false</code></em></td>
+  </tr>
+</table>
 
 ### DietPi Changes
 

--- a/readme.md
+++ b/readme.md
@@ -6,25 +6,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 ![Updated](https://img.shields.io/github/last-commit/thushan/proxmox-vm-to-ct)
-![Proxmox](https://img.shields.io/badge/-Proxmox-orange)
-![DietPi](https://img.shields.io/badge/-DietPi-C1FF00)
+![Version](https://img.shields.io/badge/Version-v0.9.0-blue)
+![Proxmox](https://img.shields.io/badge/Proxmox-7.x%20%7C%208.x-orange?logo=proxmox)
+![DietPi](https://img.shields.io/badge/DietPi-6.x%20%7C%207.x%20%7C%208.x-C1FF00?logo=dietpi)
 
 </div>
-
-<table>
-  <tr>
-    <th>Script Version</th>
-    <td><a href="https://github.com/thushan/proxmox-vm-to-ct/blob/main/proxmox-vm-to-ct.sh">v0.8.2</a></td>
-  </tr>
-  <tr>
-    <th>Proxmox Versions</th>
-    <td>Proxmox 7.x | Proxmox 8.x</td>
-  </tr>
-  <tr>
-    <th>DietPi Versions</th>
-    <td>DietPi 6.x | 7.x | 8.x</td>
-  </tr>
-</table>
 
 This repository contains scripts and helpers to convert your [Proxmox](https://www.proxmox.com) VM's to containers - with a special emphasis on [DietPi](https://dietpi.com/) VMs, but [the tweaks for DietPi](#dietpi-changes) are ignored on non-DietPi distributions.
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,8 @@ See further [examples](#Examples) below.
 >
 > If you don't want to keep the `*.targ.gz` file around, you can use the `--cleanup` switch to delete it after use.
 >
-> However, if you want to retain the files for later, you can use the `--source-output` argument with a path to save it.
+> However, if you want to retain the files for later, you can use the `--source-output` argument with a path to save it or `--no-cleanup` to keep temporary files.
+> 
 > Eg. `--source-output ~/dietpi-first-attempt.tar.gz`
 
 

--- a/readme.md
+++ b/readme.md
@@ -179,7 +179,7 @@ Options:
   --default-config
       Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)
   --default-config-containerd, --default-config-docker
-      Default configuration for creating a containerd container (2 CPU, 2GB RAM, 20GB Disk, privileged, features: nesting, keyctl)
+      Default configuration for containerd containers (default + privileged, features: nesting, keyctl)
   --ignore-prep
       Ignore modifying the VM before snapshotting
   --ignore-dietpi

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 <table>
   <tr>
     <th>Script Version</th>
-    <td><a href="https://github.com/thushan/proxmox-vm-to-ct/blob/main/proxmox-vm-to-ct.sh">v0.8.1</a></td>
+    <td><a href="https://github.com/thushan/proxmox-vm-to-ct/blob/main/proxmox-vm-to-ct.sh">v0.8.2</a></td>
   </tr>
   <tr>
     <th>Proxmox Versions</th>
@@ -148,9 +148,22 @@ If you want to avoid [changes to the vm](#dietpi-changes) by the script, use the
                       --ignore-prep
 ```
 
+#### Containerd VM to CT
+
+The [default CT configuration](#default-configuration) is not designed for VMs that have a containerd (Docker/Podman) engine installed. If your VM has Docker or Podman installed, converting to a CT will generate errors as described in [ISSUE: Failed to Create CT](https://github.com/thushan/proxmox-vm-to-ct/issues/2#issuecomment-1898335593).
+
+You can create a privilleged container with additional features required (`nesting` & `keyctl`) by using the `--default-config-containerd` (or `--default-config-docker`)
+
+```
+./proxmox-vm-to-ct.sh --source 192.168.0.152 \
+                      --target the-matrix-reloaded \
+                      --storage local-lvm \
+                      --default-config-docker
+```
+
 ## Usage
 ```
-Usage: proxmox-vm-to-ct.sh --storage <name> --target <name> --source <hostname> [options]
+Usage: proxmox-vm-to-ct.sh --source <hostname> --target <name> --storage <name> [options]
 
 Options:
   --storage <name>
@@ -165,6 +178,8 @@ Options:
       Cleanup the source compressed image after conversion (the *.tar.gz file)
   --default-config
       Default configuration for container (2 CPU, 2GB RAM, 20GB Disk)
+  --default-config-docker
+      Default configuration for a docker container (2 CPU, 2GB RAM, 20GB Disk, privileged, features: nesting, keyctl)
   --ignore-prep
       Ignore modifying the VM before snapshotting
   --ignore-dietpi


### PR DESCRIPTION
This PR tries to solve #2 which was an example of a VM that had an installation of Docker that was being converted to a CT via `proxmox-vm-to-ct` but the default  configuration does not support that use case.

![proxmox-docker-container-issue](https://github.com/thushan/proxmox-vm-to-ct/assets/68254/6cd0bba9-2cdb-4c48-93ac-61ff37351cbf)

This PR introduces a new default configuration for these scenario where containerd is installed on VM to enable:

- Privileged Container
- Features: `nesting` & `keyctl`

These are activated when you use the `--default-config-containerd` or the `--default-config-docker` switch.

```bash
proxmox-vm-to-ct.sh --source 192.168.0.152 \
                      --target the-matrix-reloaded \
                      --storage local-lvm \
                      --default-config-docker
```

After this PR and using the switch above:

![image](https://github.com/thushan/proxmox-vm-to-ct/assets/68254/001d752d-b081-40cc-9fe9-a7e67426d7be)

The [documentation](https://pve.proxmox.com/pve-docs/pct.1.html) states:

![image](https://github.com/thushan/proxmox-vm-to-ct/assets/68254/65cbb4ae-7e70-4b01-9553-f972dbf966a0)
![image](https://github.com/thushan/proxmox-vm-to-ct/assets/68254/b9079cb4-9a6d-472e-984c-e2d95790453a)

Ideally we would want to use `unprivileged: 1` but that won't work with this scenario.
