### PR TITLE
SSH Options

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "mads-hartmann.bash-ide-vscode",
+        "aaron-bond.better-comments"
+    ]
+}

--- a/default.config
+++ b/default.config
@@ -11,3 +11,4 @@ CT_ONBOOT=0
 CT_ARCH=amd64
 CT_OSTYPE=debian
 # NOTE: Requires an empty new line at the end
+

--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -16,6 +16,8 @@ if [[ "${TRACE-0}" == "1" ]]; then
 fi
 
 PVE_SOURCE=""
+PVE_SOURCE_PORT=22
+PVE_SOURCE_USER=root
 PVE_TARGET=""
 PVE_STORAGE=""
 PVE_SOURCE_OUTPUT=""
@@ -522,7 +524,7 @@ function create_vm_snapshot() {
     tput cup 0 0
     banner 1
 
-    ssh "root@$PVE_SOURCE" \
+    ssh "$PVE_SOURCE_USER@$PVE_SOURCE" -p "$PVE_SOURCE_PORT" \
         "$(typeset -f vm_ct_prep); $(typeset -f vm_ct_prep_dietpi); $(typeset -f vm_fs_snapshot); $(declare -p OPT_IGNORE_DIETPI OPT_IGNORE_PREP); vm_ct_prep; vm_fs_snapshot" \
         >"$PVE_SOURCE_OUTPUT"
 
@@ -635,6 +637,10 @@ function usage() {
     echo "      Name of the Proxmox Storage container (Eg. local-zfs, local-lvm, etc)"
     echo "  ${CCyan}--source${ENDMARKER} <hostname> | <file: *.tar.gz>"
     echo "      Source VM to convert to CT (Eg. postgres-vm.fritz.box or 192.168.0.10, source-vm.tar.gz file locally)"
+    echo "  ${CCyan}--source-user${ENDMARKER} <username>"
+    echo "      Source VM's SSH username to connect with. (Eg. ${CGreen}root${ENDMARKER}) "
+    echo "  ${CCyan}--source-port${ENDMARKER} <port>"
+    echo "      Source VM's SSH port to connect to. (Eg. ${CGreen}22${ENDMARKER}) "
     echo "  ${CCyan}--source-output${ENDMARKER} <path>, ${CCyan}--output${ENDMARKER} <path>, ${CCyan}-o${ENDMARKER} <path>"
     echo "      Location of the source VM output (default: ${CGreen}/tmp/proxmox-vm-to-ct/<hostname>.tar.gz${ENDMARKER})"
     echo "  ${CCyan}--target${ENDMARKER} <name>"
@@ -665,6 +671,14 @@ while [ "$#" -gt 0 ]; do
         ;;
     --source)
         PVE_SOURCE="$2"
+        shift
+        ;;
+    --source-port)
+        PVE_SOURCE_PORT=$2
+        shift
+        ;;
+    --source-user)
+        PVE_SOURCE_USER=$2
         shift
         ;;
     --storage)

--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -670,7 +670,7 @@ function main() {
 
 function usage() {
     banner 0
-    echo "Usage: ${CYellow}$0${ENDMARKER} ${CBlue}--source${ENDMARKER} <hostname> ${CBlue}--target${ENDMARKER} <name> ${CBlue}--storage${ENDMARKER} <name> [options]"
+    echo "Usage: ${CYellow}$0${ENDMARKER} ${CBlue}--storage${ENDMARKER} <name> ${CBlue}--source${ENDMARKER} <hostname|file> ${CBlue}--target${ENDMARKER} <name> [options]"
     echo "Options:"
     echo "  ${CCyan}--storage${ENDMARKER} <name>"
     echo "      Name of the Proxmox Storage container (Eg. local-zfs, local-lvm, etc)"

--- a/proxmox-vm-to-ct.sh
+++ b/proxmox-vm-to-ct.sh
@@ -534,7 +534,7 @@ function create_vm_snapshot() {
     cursor_restore
     CT_SCREENP=0
     if [ $ssh_status -ne 0 ]; then
-        error "SSH to $PVE_SOURCE_USER@$PVE_SOURCE:$PVE_SOURCE_PORT failed with: $exit_status"
+        fatal "SSH to $PVE_SOURCE_USER@$PVE_SOURCE:$PVE_SOURCE_PORT failed with: $ssh_status"
     fi
     msg_done "$c_status"
 }

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ wget https://raw.githubusercontent.com/thushan/proxmox-vm-to-ct/main/proxmox-vm-
 chmod +x ./proxmox-vm-to-ct.sh
 ```
 
-Once downloaded, to create an container for the vm '`the-matrix`' named '`matrix-reloaded`' with the [default CT configuration](#default-configuration) on your pve storage `local-zfs`:
+Once downloaded, to create an container for the vm with the hostname '`the-matrix`' named '`matrix-reloaded`' with the [default CT configuration](#default-configuration) on your pve storage `local-zfs`:
 
 ```shell
 ./proxmox-vm-to-ct.sh --source the-matrix \
@@ -48,6 +48,8 @@ If your VM has docker, podman or containerd installed, use the `--default-config
                       --storage local-zfs \
                       --default-config-containerd
 ```
+
+You can use the fully qualified host name (Eg. `the-matrix` or `the-matrix.fritz.box`) or the IP (Eg. `192.168.0.101`) of the source VM you want to convert - we SSH in, to get the files.
 
 See further [examples](#Examples) below.
 
@@ -237,13 +239,17 @@ See what's included with [default containerd](#default-configuration---container
 
 ## Usage
 ```
-Usage: proxmox-vm-to-ct.sh --source <hostname> --target <name> --storage <name> [options]
+Usage: proxmox-vm-to-ct.sh --storage <name> --source <hostname|file> --target <name> [options]
 
 Options:
   --storage <name>
       Name of the Proxmox Storage container (Eg. local-zfs, local-lvm, etc)
   --source <hostname> | <file: *.tar.gz>
       Source VM to convert to CT (Eg. postgres-vm.fritz.box or 192.168.0.10, source-vm.tar.gz file locally)
+  --source-user <username>
+      Source VM's SSH username to connect with. (Eg. root)
+  --source-port <port>
+      Source VM's SSH port to connect to. (Eg. 22)
   --source-output <path>, --output <path>, -o <path>
       Location of the source VM output (default: /tmp/proxmox-vm-to-ct/<hostname>.tar.gz)
   --target <name>


### PR DESCRIPTION
This PR introduces `source-port` and `source-user` for SSH sessions.

```
$ ./proxmox-vm-to-ct.sh --source 192.168.0.101 --source-user postgres --source-port 99 --target postgres-timescaledb
```

Also failures in SSH connections or setup will output a FATAL message so one is aware of SSH errors - though, most of the time it's a status code of `255`.